### PR TITLE
chore: ESLint, Prettier 설정

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,6 @@
+# 기본 방어선
+node_modules/
+dist/
+build/
+public/
+.vscode/

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,29 @@
+/* eslint-disable no-undef */
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  plugins: ['react', '@typescript-eslint', 'prettier', 'import'], // ✅ import 추가
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
+    'plugin:import/typescript', // ✅ import 관련 규칙 확장
+  ],
+  rules: {
+    'prettier/prettier': 'error',
+    'react/react-in-jsx-scope': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+    'import/order': 'warn', // ✅ optional: import 순서 정리
+    'import/no-unresolved': 'error', // ✅ alias 인식 안 되면 잡아냄
+    'react/function-component-definition': ['error', { namedComponents: 'arrow-function' }], // ✅ React 컴포넌트만 화살표 함수 강제
+  },
+  settings: {
+    react: {
+      version: 'detect',
+    },
+    'import/resolver': {
+      typescript: {}, // ✅ tsconfig.json을 기반으로 경로 alias 인식
+    },
+  },
+};

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+# 포맷 제외 폴더
+public/
+dist/
+build/
+node_modules/
+.vscode/
+
+src/index.css

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "arrowParens": "always"
+}


### PR DESCRIPTION
ESLint v9.0.0 이상 ESM 설정 -> v8.0.0으로 다운그레이드
React 컴포넌트만 화살표 함수 강제
lint, format 스크립트 설정
.env.example 환경변수 템플릿 지정